### PR TITLE
削除機能の実装(backのみ)

### DIFF
--- a/src/controllers/create-knowledge.controller.tsx
+++ b/src/controllers/create-knowledge.controller.tsx
@@ -1,5 +1,4 @@
 import { KnowledgeCreateFeature } from '../features/KnowledgeCreateFeature.js';
-import { KnowledgeListFeature } from '../features/KnowledgeListFeature.js';
 import { Knowledge } from '../models/knowledge.model.js';
 import { KnowledgeRepository } from '../models/knowledge.repository.js';
 
@@ -15,9 +14,8 @@ export async function createKnowledgeController(userId: string, content: string)
   try {
     const knowledge = Knowledge.create(content.trim(), userId);
     await KnowledgeRepository.upsert(knowledge);
-    const knowledges = await KnowledgeRepository.getAll_api();
 
-    return <KnowledgeListFeature knowledges={knowledges} userId={userId} />;
+    return null;
   } catch (error) {
     console.error(error);
 

--- a/src/controllers/delete-knowledge.controller.tsx
+++ b/src/controllers/delete-knowledge.controller.tsx
@@ -1,0 +1,25 @@
+import type { Knowledge } from '../models/knowledge.model.js';
+import { KnowledgeRepository } from '../models/knowledge.repository.js';
+
+export async function deleteKnowledgeController(userId: string, knowledgeId: string) {
+  let knowledge: Knowledge;
+
+  try {
+    knowledge = await KnowledgeRepository.getByKnowledgeId(knowledgeId);
+  } catch (error) {
+    console.error(error);
+    return <div>ナレッジが見つかりません</div>;
+  }
+
+  if (userId !== knowledge.authorId) {
+    return <div>このナレッジを削除する権限がありません</div>;
+  }
+
+  try {
+    await KnowledgeRepository.deleteByKnowledgeId(knowledgeId);
+    return null;
+  } catch (error) {
+    console.error(error);
+    return <div>削除に失敗しました</div>;
+  }
+}

--- a/src/controllers/get-all-knowledges.controller.tsx
+++ b/src/controllers/get-all-knowledges.controller.tsx
@@ -2,7 +2,7 @@ import { KnowledgeListFeature } from '../features/KnowledgeListFeature.js';
 import { KnowledgeRepository } from '../models/knowledge.repository.js';
 
 export async function getAllKnowledgesController(userId: string) {
-  const knowledges = await KnowledgeRepository.getAll_api();
+  const knowledges = await KnowledgeRepository.getAll();
 
   return <KnowledgeListFeature knowledges={knowledges} userId={userId} />;
 }

--- a/src/models/knowledge.repository.ts
+++ b/src/models/knowledge.repository.ts
@@ -43,9 +43,13 @@ export const KnowledgeRepository = {
     return knowledges.filter((knowledge) => knowledge.authorId === authorId);
   },
 
+  async getAll(): Promise<Knowledge[]> {
+    return await getAll();
+  },
+
   async getAll_api() {
     // 全てのナレッジを取得
-    return await getAll();
+    return await this.getAll();
   },
   /**
    * @description ナレッジを保存する関数

--- a/src/models/knowledge.repository.ts
+++ b/src/models/knowledge.repository.ts
@@ -44,12 +44,10 @@ export const KnowledgeRepository = {
   },
 
   async getAll(): Promise<Knowledge[]> {
-    return await getAll();
-  },
+    const files = await Array.fromAsync(glob(`${STORAGE_DIR}/**/*.json`));
+    const knowledges = await Promise.all(files.map((file) => readKnowledge(file)));
 
-  async getAll_api() {
-    // 全てのナレッジを取得
-    return await this.getAll();
+    return knowledges;
   },
   /**
    * @description ナレッジを保存する関数

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,6 +3,7 @@ import {
   createKnowledgeController,
   showCreateKnowledgeFormController,
 } from './controllers/create-knowledge.controller.js';
+import { deleteKnowledgeController } from './controllers/delete-knowledge.controller.js';
 import { getAllKnowledgesController } from './controllers/get-all-knowledges.controller.js';
 
 export interface Variables {
@@ -29,4 +30,22 @@ router.post('/knowledges', async (ctx) => {
   const content = body['content'];
 
   return ctx.html(await createKnowledgeController(userId, content as string));
+});
+
+router.post('/knowledges/:knowledgeId/delete', async (ctx) => {
+  const userId = ctx.get('userId');
+  const knowledgeId = ctx.req.param('knowledgeId');
+
+  try {
+    const result = await deleteKnowledgeController(userId, knowledgeId);
+
+    if (result === null) {
+      return ctx.redirect('/');
+    }
+
+    return ctx.html(result);
+  } catch (error) {
+    console.error('Error in POST /knowledges/:knowledgeId/delete:', error);
+    return ctx.text('Internal Server Error', 500);
+  }
 });

--- a/src/router.ts
+++ b/src/router.ts
@@ -29,7 +29,18 @@ router.post('/knowledges', async (ctx) => {
   const body = await ctx.req.parseBody();
   const content = body['content'];
 
-  return ctx.html(await createKnowledgeController(userId, content as string));
+  try {
+    const result = await createKnowledgeController(userId, content as string);
+
+    if (result === null) {
+      return ctx.redirect('/', 303);
+    }
+
+    return ctx.html(result);
+  } catch (error) {
+    console.error('Error in POST /knowledges:', error);
+    return ctx.text('Internal Server Error', 500);
+  }
 });
 
 router.post('/knowledges/:knowledgeId/delete', async (ctx) => {
@@ -40,7 +51,7 @@ router.post('/knowledges/:knowledgeId/delete', async (ctx) => {
     const result = await deleteKnowledgeController(userId, knowledgeId);
 
     if (result === null) {
-      return ctx.redirect('/');
+      return ctx.redirect('/', 303);
     }
 
     return ctx.html(result);


### PR DESCRIPTION
削除機能の裏側のみを実装した。

[未実装]
削除ボタン(UI)

[動作確認方法]

npm start -- "test-user" でサーバ起動
ブラウザで http://localhost:8080/knowledges/new にアクセス
テキストを入力して投稿

サーバ起動とは別のターミナルで以下を実施
削除前にナレッジ ID をメモ
ls -la storage/

curl で削除実行
curl -X POST http://localhost:8080/knowledges/{ナレッジID}/delete \
  -H "Cf-Access-Jwt-Assertion: test-user" \
  -L

削除後にファイルが消えたか確認
ls -la storage/